### PR TITLE
ES index name constants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.rcsb</groupId>
 	<artifactId>rcsb-common</artifactId>
-	<version>2.11.1-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>rcsb-common</name>
 	<description>Common constants for RCSB projects.</description>

--- a/src/main/java/org/rcsb/common/constants/ContentType.java
+++ b/src/main/java/org/rcsb/common/constants/ContentType.java
@@ -6,10 +6,9 @@ package org.rcsb.common.constants;
  * models.
  *
  * Created on 3/17/22.
- * TODO: fix @since tag
  *
  * @author Yana Rose
- * @since X.Y.Z
+ * @since 2.6.0
  */
 public enum ContentType {
     experimental,

--- a/src/main/java/org/rcsb/common/constants/ElasticsearchConstants.java
+++ b/src/main/java/org/rcsb/common/constants/ElasticsearchConstants.java
@@ -12,36 +12,6 @@ public class ElasticsearchConstants {
     // this collection of static members cannot be instantiated.
     private ElasticsearchConstants() {}
 
-    // specialized index for auto-complete feature
-    public static final String INDEX_SUGGESTER = "suggester";
-    public static final String INDEX_SUGGESTER_COMP_MODEL = "suggester_comp_model";
-    
-    public static final String INDEX_TERMS_COMPLETION = "terms_autocomplete";
-    public static final String INDEX_TERMS_COMPLETION_COMP_MODEL = "terms_autocomplete_comp_model";
-
-    public static final String INDEX_UNSTRUCTURED_ENTRY = "unstructured_entry";
-    public static final String INDEX_UNSTRUCTURED_ENTRY_COMP_MODEL = "unstructured_entry_comp_model";
-
-    public static final String INDEX_DENORMALIZED_ENTRY = "combined_entry";
-    public static final String INDEX_DENORMALIZED_ENTRY_COMP_MODEL = "combined_entry_comp_model";
-
-    public static final String INDEX_DENORMALIZED_ASSEMBLY = "combined_assembly";
-    public static final String INDEX_DENORMALIZED_ASSEMBLY_COMP_MODEL = "combined_assembly_comp_model";
-
-    public static final String INDEX_DENORMALIZED_POLYMER_ENTITY = "combined_polymer_entity";
-    public static final String INDEX_DENORMALIZED_POLYMER_ENTITY_COMP_MODEL = "combined_polymer_entity_comp_model";
-
-    public static final String INDEX_DENORMALIZED_POLYMER_ENTITY_INSTANCE = "combined_polymer_instance";
-    public static final String INDEX_DENORMALIZED_POLYMER_ENTITY_INSTANCE_COMP_MODEL = "combined_polymer_instance_comp_model";
-
-    public static final String INDEX_DENORMALIZED_BRANCHED_ENTITY = "combined_branched_entity";
-    public static final String INDEX_DENORMALIZED_NON_POLYMER_ENTITY = "combined_non_polymer_entity";
-    public static final String INDEX_DENORMALIZED_MOL_DEFINITION = "combined_mol_definition";
-
-    public static final String INDEX_UNRELEASED_ENTRY = "unreleased_entry";
-
-    public static final String INDEX_DENORMALIZED_GROUPS = "combined_groups";
-
     // 'keyword' is an arbitrary word chosen to namespace fields indexed for exact match searches,
     // when input is not analyzed
     public static final String KEYWORD_SUFFIX = "keyword";

--- a/src/main/java/org/rcsb/common/constants/ElasticsearchIndexName.java
+++ b/src/main/java/org/rcsb/common/constants/ElasticsearchIndexName.java
@@ -27,6 +27,8 @@ public enum ElasticsearchIndexName {
     /** Represents the index for combined polymer entity component models. */
     denormalized_polymer_entity("combined_polymer_entity_pdb", "combined_polymer_entity_csm", "combined_polymer_entity_all"),
 
+    denormalized_polymer_entity_instance("combined_polymer_entity_instance_pdb", "combined_polymer_entity_instance_csm", "combined_polymer_entity_instance_all"),
+
     /** Represents the index for combined branched entity models. */
     denormalized_branched_entity("combined_branched_entity_pdb", "combined_branched_entity_csm", "combined_branched_entity_all"),
 

--- a/src/main/java/org/rcsb/common/constants/ElasticsearchIndexName.java
+++ b/src/main/java/org/rcsb/common/constants/ElasticsearchIndexName.java
@@ -1,63 +1,51 @@
 package org.rcsb.common.constants;
 
+import java.util.Map;
+
 /**
  * A name of an Elasticsearch index used by the RCSB PDB.
- * Each enum constant represents a specific Elasticsearch index,
- * defined by its associated index name string.
+ * Each enum constant represents a specific Elasticsearch index type,
+ * with associated index names strings.
  */
 public enum ElasticsearchIndexName {
 
     /** Represents the index for suggester component models. */
-    suggester("suggester_comp_model"),
-
-    /** Represents the experimental-only index for suggesters. */
-    suggester_experimental_only("suggester"),
+    suggester("suggester_pdb", "suggester_csm", "suggester_all"),
 
     /** Represents the index for autocomplete component models. */
-    autocomplete("terms_autocomplete_comp_model"),
-
-    /** Represents the experimental-only index for autocompletes. */
-    autocomplete_experimental_only("terms_autocomplete"),
+    autocomplete("terms_autocomplete_pdb", "terms_autocomplete_csm", "terms_autocomplete_all"),
 
     /** Represents the index for unstructured entry component models. */
-    unstructured_entry("unstructured_entry_comp_model"),
+    unstructured_entry("unstructured_entry_pdb", "unstructured_entry_csm", "unstructured_entry_all"),
 
     /** Represents the index for combined entry component models. */
-    denormalized_entry("combined_entry_comp_model"),
+    denormalized_entry("combined_entry_pdb", "combined_entry_csm", "combined_entry_all"),
 
     /** Represents the index for combined assembly component models. */
-    denormalized_assembly("combined_assembly_comp_model"),
+    denormalized_assembly("combined_assembly_pdb", "combined_assembly_csm", "combined_assembly_all"),
 
     /** Represents the index for combined polymer entity component models. */
-    denormalized_polymer_entity("combined_polymer_entity_comp_model"),
+    denormalized_polymer_entity("combined_polymer_entity_pdb", "combined_polymer_entity_csm", "combined_polymer_entity_all"),
 
     /** Represents the index for combined branched entity models. */
-    denormalized_branched_entity("combined_branched_entity"),
+    denormalized_branched_entity("combined_branched_entity_pdb", "combined_branched_entity_csm", "combined_branched_entity_all"),
 
     /** Represents the index for combined non-polymer entity models. */
-    denormalized_non_polymer_entity("combined_non_polymer_entity"),
+    denormalized_non_polymer_entity("combined_non_polymer_entity_pdb", "combined_non_polymer_entity_csm", "combined_non_polymer_entity_all"),
 
     /** Represents the index for combined molecular definition models. */
-    denormalized_mol_definition("combined_mol_definition"),
+    denormalized_mol_definition("combined_mol_definition_pdb", "combined_mol_definition_csm", "combined_mol_definition_all"),
 
     /** Represents the index for unreleased entries. */
-    unreleased_entry("unreleased_entry"),
+    unreleased_entry("unreleased_entry_pdb", "unreleased_entry_csm", "unreleased_entry_all");
 
-    /** Represents the index for combined groups models. */
-    denormalized_groups("combined_groups");
+    private final Map<LoadPdbCsmType, String> indexNamesByLoadType;
 
-    private final String name;
-
-    ElasticsearchIndexName(String name) {
-        this.name = name;
+    ElasticsearchIndexName(String namePdb, String nameCsm, String nameAll) {
+        indexNamesByLoadType = Map.of(LoadPdbCsmType.PDB, namePdb, LoadPdbCsmType.CSM, nameCsm, LoadPdbCsmType.ALL, nameAll);
     }
 
-    /**
-     * Returns the name of the Elasticsearch index associated with the enum constant.
-     */
-    @Override
-    public String toString() {
-        return name;
+    public String getIndexName(LoadPdbCsmType loadType) {
+        return indexNamesByLoadType.get(loadType);
     }
-
 }

--- a/src/main/java/org/rcsb/common/constants/LoadPdbCsmType.java
+++ b/src/main/java/org/rcsb/common/constants/LoadPdbCsmType.java
@@ -1,8 +1,20 @@
 package org.rcsb.common.constants;
 
+import java.util.List;
+
 public enum LoadPdbCsmType {
-    PDB,
-    CSM,
-    ALL;
+
+    PDB(ContentType.experimental),
+    CSM(ContentType.computational),
+    ALL(ContentType.experimental, ContentType.computational);
+
+    private final List<ContentType> contentTypes;
+    LoadPdbCsmType(ContentType... contentTypes) {
+        this.contentTypes = List.of(contentTypes);
+    }
+
+    public List<ContentType> getContentTypes() {
+        return contentTypes;
+    }
 
 }

--- a/src/main/java/org/rcsb/common/constants/LoadPdbCsmType.java
+++ b/src/main/java/org/rcsb/common/constants/LoadPdbCsmType.java
@@ -1,0 +1,8 @@
+package org.rcsb.common.constants;
+
+public enum LoadPdbCsmType {
+    PDB,
+    CSM,
+    ALL;
+
+}

--- a/src/main/java/org/rcsb/common/constants/LoadPdbCsmType.java
+++ b/src/main/java/org/rcsb/common/constants/LoadPdbCsmType.java
@@ -1,20 +1,9 @@
 package org.rcsb.common.constants;
 
-import java.util.List;
 
 public enum LoadPdbCsmType {
 
-    PDB(ContentType.experimental),
-    CSM(ContentType.computational),
-    ALL(ContentType.experimental, ContentType.computational);
-
-    private final List<ContentType> contentTypes;
-    LoadPdbCsmType(ContentType... contentTypes) {
-        this.contentTypes = List.of(contentTypes);
-    }
-
-    public List<ContentType> getContentTypes() {
-        return contentTypes;
-    }
-
+    PDB,
+    CSM,
+    ALL;
 }


### PR DESCRIPTION
Remove index names from ElasticsearchConstants in favour of the enum ElasticsearchIndexName (already existing, but unused until now).